### PR TITLE
feat(ipadp): L1-L3 conformance + Cline harmony metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,4 +430,60 @@ Implementation: Extends `YamlIntegration` (parallel to `TomlIntegration`):
 
 ---
 
+## IPADP Conformance & Cline Harmony
+
+This fork of `spec-kit` participates in the **Inter-Project Agentic Development
+Process (IPADP)** as project #6. It targets **L3 conformance** — the highest
+level defined in the IPADP RFC.
+
+See: `specs/metadata.json`, `llms.txt`, and the IPADP RFC hosted in the
+internal satware AG `wiki` repository (`specs/rfc-interproject-agentic-development.md`).
+
+### Conformance Matrix
+
+| Level | Requirement | Artifact in this repo |
+|-------|-------------|-----------------------|
+| L1    | `AGENTS.md` + `specs/metadata.json` with upstream/downstream graph | This file + `specs/metadata.json` |
+| L2    | Privacy validation in CI                                          | `scripts/bash/check-privacy-leaks.sh`, `.privacy-whitelist`, `.github/workflows/privacy-check.yml` |
+| L3    | Automated upstream sync + morning protocol integration            | `scripts/bash/check-upstream-sync.sh`, Cline `sod.protocol.md` / `eod.protocol.md` |
+
+### Harmony with `~/Documents/Cline`
+
+Agents working on this repository MUST follow the global satware AG agent rules
+distributed via the Cline command center. The canonical source of truth is
+`~/Documents/Cline/Rules/`, synchronized into consumer projects via
+`~/Documents/Cline/scripts/env-setup-symlinks.sh`.
+
+Key rules that govern SDD/TDD and day-to-day behavior on spec-kit:
+
+- `methodology.core.md` — core SDD/TDD/RLM methodology
+- `methodology.rlm.md`  — Reasoning, Learning, Memory loop
+- `code.quality.md`     — code quality bar, reviews, refactoring
+- `git.standards.md`    — commit conventions, branch model, PR hygiene
+- `context.management.md` — git-native context and zero-persistence memory
+- `docs.markdown.md`    — markdown + frontmatter rules
+- `agent.framework.md`, `agent.guardrails.md` — operational framework and guardrails
+
+### Morning / EoD Protocol Integration
+
+At the start of every working session an agent working on this repository SHOULD:
+
+1. Run the Cline **Start-of-Day** protocol: `~/Documents/Cline/Workflows/sod.protocol.md`
+2. Execute `scripts/bash/check-upstream-sync.sh` to detect new upstream `github/spec-kit` release tags.
+3. Run `scripts/bash/check-privacy-leaks.sh` before any push to verify privacy boundaries.
+4. At the end of the session, run the Cline **End-of-Day** protocol: `~/Documents/Cline/Workflows/eod.protocol.md`
+
+### SDD/TDD Workflow (short form)
+
+1. **Spec first** — create or update a spec under `specs/<feature>/spec.md` using `templates/spec-template.md`.
+2. **Plan** — derive `specs/<feature>/plan.md` from `templates/plan-template.md`.
+3. **Tasks** — break down into verifiable tasks (`templates/tasks-template.md`).
+4. **Test-first** — add failing tests under `tests/` before implementation.
+5. **Implement** — make the tests pass with the minimum change set.
+6. **Checklists** — fulfill `templates/checklist-template.md` prior to merge.
+7. **Privacy + upstream sync** — verify via the two scripts above.
+8. **Commit + PR** — follow `git.standards.md` (conventional commits, signed trailers where required).
+
+---
+
 *This documentation should be updated whenever new integrations are added to maintain accuracy and completeness.*

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,42 @@
+# spec-kit (satwareAG fork)
+
+Comprehensive toolkit for Spec-Driven Development (SDD) and Test-Driven Development (TDD).
+This fork adds the `cline` and `hermes` agent integrations on top of upstream
+`github/spec-kit`. It is IPADP project #6 in the satware AG ecosystem.
+
+## Status
+
+- Fork version: satware-v0.7.3+1
+- Upstream version: 0.7.3
+- IPADP conformance level: L3 (AGENTS.md + specs/metadata.json + privacy validation + morning protocol)
+
+## Docs
+
+- SDD methodology: /spec-driven.md
+- Agent integration guide: /AGENTS.md
+- Contribution guide: /CONTRIBUTING.md
+- Development guide: /DEVELOPMENT.md
+- Changelog: /CHANGELOG.md
+- IPADP metadata: /specs/metadata.json
+
+## Templates
+
+- Spec template: /templates/spec-template.md
+- Plan template: /templates/plan-template.md
+- Tasks template: /templates/tasks-template.md
+- Checklist template: /templates/checklist-template.md
+- Constitution template: /templates/constitution-template.md
+
+## Repos
+
+- Source (fork): https://github.com/satwareAG/spec-kit
+- Upstream: https://github.com/github/spec-kit
+- Issues: https://github.com/satwareAG/spec-kit/issues
+- Coordination hub (IPADP RFC): internal satware AG `wiki` repository
+
+## IPADP
+
+- RFC: `specs/rfc-interproject-agentic-development.md` in the internal satware AG `wiki` repository
+- Morning protocol (SoD): `~/Documents/Cline/Workflows/sod.protocol.md`
+- EoD protocol: `~/Documents/Cline/Workflows/eod.protocol.md`
+- Global agent rules: `~/Documents/Cline/Rules/`

--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -1,20 +1,71 @@
 {
   "name": "spec-kit",
-  "version": "0.7.2",
+  "version": "0.7.3",
+  "fork_version": "satware-v0.7.3+1",
   "sdd_source": "https://github.com/satwareAG/spec-kit",
+  "forge": "github",
+  "visibility": "public",
+  "ipadp": {
+    "project_number": 6,
+    "conformance_level": "L3",
+    "issue_tracker": "https://github.com/satwareAG/spec-kit/issues/6",
+    "rfc_location": "<internal>/wiki/specs/rfc-interproject-agentic-development.md"
+  },
   "upstream": {
     "github/spec-kit": {
       "url": "https://github.com/github/spec-kit",
+      "forge": "github",
+      "channel": "gh:issues",
       "paths": {
         "specs": "specs/",
         "tests": "tests/",
         "code": "src/"
-      },
-      "channel": "gh:issues"
+      }
+    }
+  },
+  "downstream": {
+    "cline-rules": {
+      "forge": "gitlab",
+      "visibility": "private",
+      "role": "consumes SDD methodology + templates"
+    },
+    "wiki": {
+      "forge": "gitea",
+      "visibility": "private",
+      "role": "coordination hub; hosts IPADP RFC"
+    },
+    "amicron-platform": {
+      "forge": "gitlab",
+      "visibility": "private",
+      "role": "transitive consumer via cline-rules"
     }
   },
   "custom_integrations": [
     "cline",
     "hermes"
-  ]
+  ],
+  "privacy": {
+    "validator": "scripts/bash/check-privacy-leaks.sh",
+    "whitelist": ".privacy-whitelist",
+    "ci_workflow": ".github/workflows/privacy-check.yml"
+  },
+  "morning_protocol": {
+    "source": "~/Documents/Cline/Workflows/sod.protocol.md",
+    "eod_source": "~/Documents/Cline/Workflows/eod.protocol.md",
+    "upstream_sync_check": "scripts/bash/check-upstream-sync.sh"
+  },
+  "cline_harmony": {
+    "rules_source": "~/Documents/Cline/Rules/",
+    "key_rules": [
+      "methodology.core.md",
+      "methodology.rlm.md",
+      "code.quality.md",
+      "git.standards.md",
+      "context.management.md",
+      "docs.markdown.md",
+      "agent.framework.md",
+      "agent.guardrails.md"
+    ],
+    "symlink_script": "~/Documents/Cline/scripts/env-setup-symlinks.sh"
+  }
 }


### PR DESCRIPTION
## Summary

Adds IPADP L1-L3 conformance metadata and documents harmony with the `~/Documents/Cline` stack.

Single commit: `8522aad` — _feat(ipadp): add L1-L3 conformance + Cline harmony metadata_

## Changes (3 files, +153 / -4)

| File | Change |
|---|---|
| `specs/metadata.json` | Bumps to `0.7.3` / `satware-v0.7.3+1`; adds full IPADP block (project #6, L3 target), downstream graph, privacy + morning-protocol + Cline-harmony references |
| `llms.txt` | New public LLM-friendly project discovery doc |
| `AGENTS.md` | New section _IPADP Conformance & Cline Harmony_: L1/L2/L3 matrix, pointers to `~/Documents/Cline/Rules/*` (methodology, code.quality, git.standards, context.management, docs.markdown, agent.framework, agent.guardrails), SoD/EoD protocol integration, short SDD/TDD workflow |

## IPADP Conformance

| Level | Requirement | Artifact |
|---|---|---|
| L1 | `AGENTS.md` + `specs/metadata.json` with upstream/downstream graph | This PR |
| L2 | Privacy validation in CI | `scripts/bash/check-privacy-leaks.sh`, `.privacy-whitelist`, `.github/workflows/privacy-check.yml` (already on main-speck) |
| L3 | Automated upstream sync + morning protocol integration | `scripts/bash/check-upstream-sync.sh`, Cline SoD/EoD protocols |

## Verification

- Branch is 1 commit ahead of `main-speck`, 0 behind.
- Privacy validator passes (no private URLs leaked).
- Docs-only commit — no code paths or tests touched. Fork agents (agy/bob/iflow/kimi/hermes/cline) unaffected.

## Related

- Continues IPADP work tracked under milestone _IPADP Phase 2: L2 Privacy Validation_.
- Pairs with issue #10 (CI workflow for privacy leak detection — the workflow file already exists on main-speck).