### PR TITLE
docs(ipadp): L3 metadata + automation doc (closes #18, #15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,7 +445,7 @@ internal satware AG `wiki` repository (`specs/rfc-interproject-agentic-developme
 |-------|-------------|-----------------------|
 | L1    | `AGENTS.md` + `specs/metadata.json` with upstream/downstream graph | This file + `specs/metadata.json` |
 | L2    | Privacy validation in CI                                          | `scripts/bash/check-privacy-leaks.sh`, `.privacy-whitelist`, `.github/workflows/privacy-check.yml` |
-| L3    | Automated upstream sync + morning protocol integration            | `scripts/bash/check-upstream-sync.sh`, Cline `sod.protocol.md` / `eod.protocol.md` |
+| L3    | Automated upstream sync + morning protocol integration            | `scripts/bash/check-upstream-sync.sh`, `.github/workflows/upstream-sync-check.yml`, `scripts/bash/sod.sh`, `scripts/bash/eod.sh`, `scripts/daily-routine.sh`, Cline `sod.protocol.md` / `eod.protocol.md` |
 
 ### Harmony with `~/Documents/Cline`
 
@@ -468,10 +468,12 @@ Key rules that govern SDD/TDD and day-to-day behavior on spec-kit:
 
 At the start of every working session an agent working on this repository SHOULD:
 
-1. Run the Cline **Start-of-Day** protocol: `~/Documents/Cline/Workflows/sod.protocol.md`
-2. Execute `scripts/bash/check-upstream-sync.sh` to detect new upstream `github/spec-kit` release tags.
-3. Run `scripts/bash/check-privacy-leaks.sh` before any push to verify privacy boundaries.
-4. At the end of the session, run the Cline **End-of-Day** protocol: `~/Documents/Cline/Workflows/eod.protocol.md`
+1. Run the repo-local SoD hook: `bash scripts/daily-routine.sh sod` (delegates to Cline `~/Documents/Cline/Workflows/sod.protocol.md`, then runs `check-privacy-leaks.sh` and `check-upstream-sync.sh`).
+2. At the end of the session, run the repo-local EoD hook: `bash scripts/daily-routine.sh eod` (delegates to Cline `~/Documents/Cline/Workflows/eod.protocol.md`, then runs `check-privacy-leaks.sh`).
+
+In CI, `.github/workflows/upstream-sync-check.yml` runs `scripts/bash/check-upstream-sync.sh` on a daily schedule and opens/updates a rolling `upstream-sync: <tag> available` issue when a new upstream `github/spec-kit` release tag is detected.
+
+See `docs/ipadp-l3-automation.md` for full details on the scheduled workflow, the SoD/EoD integration, local run instructions, and failure/override modes.
 
 ### SDD/TDD Workflow (short form)
 

--- a/docs/ipadp-l3-automation.md
+++ b/docs/ipadp-l3-automation.md
@@ -1,0 +1,116 @@
+# IPADP L3 Upstream Sync Automation
+
+This document describes the L3 automation layer of the Inter-Project Agentic
+Development Process (IPADP) on the `satwareAG/spec-kit` fork. It ties together
+the scheduled upstream-sync CI workflow and the repo-local Start-of-Day / End-of-Day
+(SoD/EoD) protocol hooks so agents and maintainers can keep the fork continuously
+aligned with upstream `github/spec-kit` while preserving fork-only agent support.
+
+See also:
+- `AGENTS.md` — IPADP Conformance & Cline Harmony section (L1/L2/L3 matrix).
+- `specs/metadata.json` — machine-readable project + IPADP metadata.
+- Internal IPADP RFC in the satware AG `wiki` repo
+  (`specs/rfc-interproject-agentic-development.md`).
+
+## 1. Scheduled upstream-sync CI workflow
+
+**File:** `.github/workflows/upstream-sync-check.yml`
+
+### Purpose
+
+Detect new upstream `github/spec-kit` release tags and surface them as a single,
+idempotent tracking issue on the fork so the maintainer can plan the next sync.
+
+### Triggers
+
+- `schedule` — daily cron.
+- `workflow_dispatch` — manual run from the Actions tab.
+
+### Behavior
+
+1. Checks out the fork with full history and tags (both origin and upstream).
+2. Runs `scripts/bash/check-upstream-sync.sh --json` to compute the latest
+   upstream release tag and whether the current fork tip is already synced.
+3. If a newer upstream tag is available, creates or updates exactly one
+   rolling issue titled `upstream-sync: <tag> available` labeled
+   `upstream-sync` + `enhancement`. Re-runs without a new tag produce no issue
+   churn (idempotent).
+4. Uses only `GITHUB_TOKEN` — no extra secrets required.
+
+### Manual run
+
+```bash
+gh workflow run upstream-sync-check.yml --repo satwareAG/spec-kit
+```
+
+### Failure modes / overrides
+
+- If upstream is unreachable, the workflow exits non-zero and the run is
+  visible in the Actions tab — no issue is created.
+- Rolling issue can be closed manually once the sync PR has landed; the
+  workflow will re-open/update it only when a *newer* upstream tag appears.
+
+## 2. Repo-local SoD / EoD hooks
+
+**Files:** `scripts/bash/sod.sh`, `scripts/bash/eod.sh`, `scripts/daily-routine.sh`.
+
+### Purpose
+
+Run the canonical satware AG daily rituals (Start-of-Day / End-of-Day protocols
+from `~/Documents/Cline/Workflows/`) locally on the repo and tie them to the
+two validation checks the fork must honor: privacy + upstream sync.
+
+### Start-of-Day (`sod`)
+
+```bash
+bash scripts/daily-routine.sh sod
+```
+
+1. References `~/Documents/Cline/Workflows/sod.protocol.md` (graceful
+   non-fatal fallback with a warning if the Cline stack is absent).
+2. Runs `scripts/bash/check-privacy-leaks.sh .`.
+3. Runs `scripts/bash/check-upstream-sync.sh`.
+
+### End-of-Day (`eod`)
+
+```bash
+bash scripts/daily-routine.sh eod
+```
+
+1. References `~/Documents/Cline/Workflows/eod.protocol.md` (graceful fallback).
+2. Runs `scripts/bash/check-privacy-leaks.sh .`.
+
+### Dispatcher
+
+`scripts/daily-routine.sh` accepts `sod`, `eod`, and `help` subcommands and is
+safe to run from any CWD inside the repo.
+
+## 3. Local run instructions
+
+```bash
+# Sanity checks
+bash scripts/daily-routine.sh help
+bash scripts/daily-routine.sh sod
+bash scripts/daily-routine.sh eod
+
+# Underlying checks directly
+bash scripts/bash/check-privacy-leaks.sh .
+bash scripts/bash/check-upstream-sync.sh
+bash scripts/bash/check-upstream-sync.sh --json
+```
+
+## 4. Failure modes and manual override
+
+| Condition | Effect | Manual override |
+|---|---|---|
+| `~/Documents/Cline/` absent | Hooks warn and continue (non-fatal). | Clone/symlink the Cline stack per `AGENTS.md` Harmony section. |
+| `upstream` remote missing | `check-upstream-sync.sh` exits non-zero. | `git remote add upstream https://github.com/github/spec-kit` then `git fetch upstream --tags`. |
+| Privacy violation detected | SoD/EoD hook fails; CI `privacy-check` workflow blocks merge. | Fix the leak or extend `.privacy-whitelist` with justification. |
+| Rolling upstream-sync issue obsolete | Close it manually. | The scheduled workflow re-creates/updates the issue only on a strictly newer upstream tag. |
+
+## 5. Conformance
+
+These artifacts satisfy the L3 row of the IPADP conformance matrix in
+`AGENTS.md`: automated upstream sync detection plus morning-protocol integration.
+Combined with L1 (`AGENTS.md` + `specs/metadata.json`) and L2 (privacy validation
+in CI), the fork reaches full IPADP L3 conformance as project #6.

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@ This fork adds the `cline` and `hermes` agent integrations on top of upstream
 - Development guide: /DEVELOPMENT.md
 - Changelog: /CHANGELOG.md
 - IPADP metadata: /specs/metadata.json
+- IPADP L3 automation: /docs/ipadp-l3-automation.md
 
 ## Templates
 

--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -52,7 +52,12 @@
   "morning_protocol": {
     "source": "~/Documents/Cline/Workflows/sod.protocol.md",
     "eod_source": "~/Documents/Cline/Workflows/eod.protocol.md",
-    "upstream_sync_check": "scripts/bash/check-upstream-sync.sh"
+    "upstream_sync_check": "scripts/bash/check-upstream-sync.sh",
+    "sod_hook": "scripts/bash/sod.sh",
+    "eod_hook": "scripts/bash/eod.sh",
+    "dispatcher": "scripts/daily-routine.sh",
+    "ci_workflow": ".github/workflows/upstream-sync-check.yml",
+    "docs": "docs/ipadp-l3-automation.md"
   },
   "cline_harmony": {
     "rules_source": "~/Documents/Cline/Rules/",


### PR DESCRIPTION
Completes IPADP Phase 3 by updating docs + metadata to reflect the L3 automation landed in PR #19.

## Closes
- #18 — IPADP Phase 3.3: Docs + metadata update for L3 conformance
- #15 — IPADP Phase 3 parent (all sub-issues #16, #17, #18 now done)

## Changes
- \`AGENTS.md\` — L3 row of the conformance matrix now lists \`.github/workflows/upstream-sync-check.yml\`, \`scripts/bash/sod.sh\`, \`scripts/bash/eod.sh\`, \`scripts/daily-routine.sh\`. Morning/EoD section rewritten to use the repo-local dispatcher and to link to the new doc.
- \`specs/metadata.json\` — \`morning_protocol\` block extended with \`sod_hook\`, \`eod_hook\`, \`dispatcher\`, \`ci_workflow\`, \`docs\`.
- \`docs/ipadp-l3-automation.md\` — new doc covering the scheduled upstream-sync workflow, SoD/EoD integration, local run instructions, and failure/override modes.
- \`llms.txt\` — pointer to the new doc.

## Verification
- \`python3 -c 'import json; json.load(open(\"specs/metadata.json\"))'\` → OK
- \`bash scripts/bash/check-privacy-leaks.sh .\` → clean (276 files)
- \`uv run pytest tests/integrations/ -x -q\` → **835 passed** in 16.56s

Docs-only change; fork agents (\`agy\`, \`bob\`, \`iflow\`, \`kimi\`, \`hermes\`, \`cline\`) unaffected.

/cc @jane-alesi