### PR TITLE
test(ipadp): fork-agent parity audit — doc + 36 assertions (closes #24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,6 +475,8 @@ In CI, `.github/workflows/upstream-sync-check.yml` runs `scripts/bash/check-upst
 
 See `docs/ipadp-l3-automation.md` for full details on the scheduled workflow, the SoD/EoD integration, local run instructions, and failure/override modes.
 
+See `docs/fork-agent-parity.md` for the fork-agent parity audit (IPADP Phase 4.3): required class attributes, inheritance chain, delta vs upstream-bundled integrations, and the regression contract enforced by `tests/integrations/test_fork_agent_parity.py`.
+
 ### SDD/TDD Workflow (short form)
 
 1. **Spec first** — create or update a spec under `specs/<feature>/spec.md` using `templates/spec-template.md`.

--- a/docs/fork-agent-parity.md
+++ b/docs/fork-agent-parity.md
@@ -1,0 +1,93 @@
+# Fork-Agent Parity Audit
+
+IPADP Phase 4.3 (issue #24) — reference documentation and regression contract
+for the fork-only AI-agent integrations shipped by `satwareAG/spec-kit`.
+
+## Fork-only agents
+
+| Key | Base class | `context_file` | Requires CLI |
+|-----|------------|----------------|--------------|
+| `agy` | `SkillsIntegration` | `AGENTS.md` | yes |
+| `bob` | `MarkdownIntegration` | `AGENTS.md` | yes |
+| `iflow` | `MarkdownIntegration` | `IFLOW.md` | yes |
+| `kimi` | `SkillsIntegration` | `KIMI.md` | yes |
+| `hermes` | `MarkdownIntegration` | `SOUL.md` | no |
+| `cline` | `MarkdownIntegration` | `.cline/rules` | yes |
+
+These agents are **not** present in upstream `github/spec-kit`. Parity with
+the upstream `IntegrationBase` contract is enforced automatically; see
+*Regression contract* below.
+
+## Required class attributes
+
+Every fork agent subclasses a base class under
+`src/specify_cli/integrations/base.py` and must declare:
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `key` | `str` | Unique identifier; for `requires_cli: True` must match the executable name. |
+| `config` | `dict` | `name`, `folder`, `commands_subdir`, `install_url`, `requires_cli`. |
+| `registrar_config` | `dict` | `dir`, `format` (`markdown`/`toml`/`yaml`), `args`, `extension`. |
+| `context_file` | `str` | Non-empty path to the agent context/instructions file. |
+
+## Inheritance chain
+
+```
+IntegrationBase
+├── MarkdownIntegration   ← bob, iflow, hermes, cline
+├── TomlIntegration
+├── YamlIntegration
+└── SkillsIntegration     ← agy, kimi
+```
+
+Fork agents use **zero custom `setup()` overrides** — all rely on the base
+classes' standard template processing. Context-file upkeep is handled by the
+marker-based upsert in `base.py` introduced upstream in v0.7.3 (PR #2259):
+fork agents do not ship per-integration `update-context.{sh,ps1}` wrappers.
+
+## Delta vs upstream-bundled integrations
+
+| Dimension | Upstream (`claude`, `gemini`, …) | Fork (`agy`, `bob`, …) |
+|-----------|----------------------------------|------------------------|
+| Base classes used | All four (incl. custom `IntegrationBase` for Copilot) | `MarkdownIntegration`, `SkillsIntegration` only |
+| Custom `setup()` overrides | Copilot, Forge | none |
+| `options()` overrides | Codex (`--skills`), Copilot, Forge | agy, kimi (`--skills` via `SkillsIntegration`) |
+| Context-update mechanism | `base.py` marker-upsert | same (inherited) |
+
+## Regression contract
+
+The test module `tests/integrations/test_fork_agent_parity.py` asserts, for
+each fork agent, that:
+
+1. The integration is registered in `INTEGRATION_REGISTRY`.
+2. `integration.key` matches the expected key (agy/bob/iflow/kimi/hermes/cline).
+3. `config` contains all required keys with correct types.
+4. `registrar_config` contains all required keys and `format` ∈
+   `{markdown, toml, yaml}`.
+5. `context_file` is a non-empty string.
+6. End-to-end: `specify init --here --integration <key> --script sh` exits 0
+   and produces at least one file under the configured commands directory
+   (`registrar_config["dir"]`).
+
+This gives **36 parametrised assertions** across the 6 fork agents. Any
+upstream change that silently breaks the `IntegrationBase` contract for fork
+agents will now fail this test before it reaches `main-speck`.
+
+## Operational runbook
+
+- When upstream `github/spec-kit` publishes a new release tag, the scheduled
+  workflow `.github/workflows/upstream-sync-check.yml` opens/updates a rolling
+  tracking issue; the companion workflow
+  `.github/workflows/upstream-tag-regression.yml` (IPADP Phase 4.1, issue #22)
+  dry-merges the tag and runs the full integration test suite — including this
+  parity module — to detect fork-agent breakage **before** a human starts the
+  sync.
+- On parity failure the remediation is always one of:
+  1. Add the missing attribute to the fork agent's `__init__.py`.
+  2. Adjust the fork agent's base class if upstream changed the contract.
+  3. If upstream has split/renamed a base class, re-pick the appropriate
+     subclass and migrate.
+
+See also:
+- `AGENTS.md` — overall integration architecture and adding-new-integration guide.
+- `docs/ipadp-l3-automation.md` — upstream-sync + SoD/EoD automation layer.

--- a/tests/integrations/test_fork_agent_parity.py
+++ b/tests/integrations/test_fork_agent_parity.py
@@ -1,0 +1,90 @@
+"""IPADP Phase 4.3 (issue #24) — Fork-agent parity audit.
+
+Asserts that every fork-only agent (not present in upstream github/spec-kit)
+satisfies the structural contract of ``IntegrationBase``:
+
+- declares ``key``, ``config``, ``registrar_config``, ``context_file``
+- ``context_file`` is a non-empty string
+- registers in the global registry
+- ``specify init --integration <key>`` succeeds and produces the configured
+  commands directory.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from specify_cli.integrations import get_integration
+from specify_cli.integrations.base import IntegrationBase
+
+
+FORK_AGENTS = ["agy", "bob", "iflow", "kimi", "hermes", "cline"]
+
+REQUIRED_CONFIG_KEYS = {"name", "folder", "commands_subdir", "install_url", "requires_cli"}
+REQUIRED_REGISTRAR_KEYS = {"dir", "format", "args", "extension"}
+
+
+@pytest.mark.parametrize("key", FORK_AGENTS)
+class TestForkAgentParity:
+    """Structural parity checks for each fork-only integration."""
+
+    def test_registered(self, key):
+        integration = get_integration(key)
+        assert integration is not None, f"Fork agent {key!r} not registered"
+        assert isinstance(integration, IntegrationBase)
+
+    def test_key_matches(self, key):
+        assert get_integration(key).key == key
+
+    def test_config_shape(self, key):
+        config = get_integration(key).config
+        assert isinstance(config, dict)
+        missing = REQUIRED_CONFIG_KEYS - set(config)
+        assert not missing, f"{key}: config missing keys {missing}"
+        assert isinstance(config["requires_cli"], bool)
+        assert isinstance(config["name"], str) and config["name"]
+        assert isinstance(config["folder"], str) and config["folder"]
+
+    def test_registrar_config_shape(self, key):
+        rc = get_integration(key).registrar_config
+        assert isinstance(rc, dict)
+        missing = REQUIRED_REGISTRAR_KEYS - set(rc)
+        assert not missing, f"{key}: registrar_config missing keys {missing}"
+        assert rc["format"] in {"markdown", "toml", "yaml"}
+
+    def test_context_file_nonempty(self, key):
+        cf = get_integration(key).context_file
+        assert isinstance(cf, str) and cf.strip(), (
+            f"{key}: context_file must be a non-empty string"
+        )
+
+    def test_specify_init_succeeds(self, key, tmp_path):
+        """End-to-end: `specify init --integration <key>` must produce
+        the configured commands directory without errors."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        integration = get_integration(key)
+        project = tmp_path / f"parity-{key}"
+        project.mkdir()
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            result = CliRunner().invoke(app, [
+                "init", "--here", "--integration", key,
+                "--script", "sh", "--no-git", "--ignore-agent-tools",
+            ], catch_exceptions=False)
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0, f"init failed for {key}: {result.output}"
+
+        commands_dir = project / integration.registrar_config["dir"]
+        assert commands_dir.exists(), (
+            f"{key}: expected commands dir {commands_dir} not created"
+        )
+        # Commands dir should contain at least one generated file.
+        produced = list(commands_dir.rglob("*"))
+        produced_files = [p for p in produced if p.is_file()]
+        assert produced_files, f"{key}: no command files produced in {commands_dir}"


### PR DESCRIPTION
## Summary
IPADP Phase 4.3 (issue #24) — formal parity audit doc + regression test module for fork-only agents.

## Changes
- **tests/integrations/test_fork_agent_parity.py** — parametrised across \`agy\`, \`bob\`, \`iflow\`, \`kimi\`, \`hermes\`, \`cline\`:
  - Registered in \`INTEGRATION_REGISTRY\`
  - \`key\` matches expected value
  - \`config\` has required keys (\`name\`, \`folder\`, \`commands_subdir\`, \`install_url\`, \`requires_cli\`) with correct types
  - \`registrar_config\` has required keys (\`dir\`, \`format\`, \`args\`, \`extension\`), format ∈ {markdown, toml, yaml}
  - \`context_file\` non-empty string
  - End-to-end \`specify init --integration <key> --script sh\` exits 0 and produces a non-empty commands dir
  - **36 parametrised assertions, all green.**
- **docs/fork-agent-parity.md** — fork-agent table, required attributes, inheritance chain, delta vs upstream, regression contract, operational runbook.
- **AGENTS.md** — pointer to the new doc from the IPADP/Cline-harmony section.

## Acceptance criteria (from issue #24)
- [x] Doc published under \`docs/\`.
- [x] Parity test passes for all 6 fork agents.
- [x] Linked from \`AGENTS.md\`.

## Verification
- \`uv run pytest tests/integrations/ -x -q\` → **871 passed** (835 existing + 36 new).
- \`scripts/bash/check-privacy-leaks.sh .\` → clean (277 files).

## Dependencies
Independent of PR #27 (#22) and PR #28 (#23); no content conflict. When #22's regression workflow lands, it will execute this parity module on every upstream tag event.

Closes #24.
/cc @jane-alesi