### PR TITLE
Decouple harness from Cline in specs/metadata.json (#65)

### DIFF
--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -24,9 +24,10 @@
     }
   },
   "downstream": {
-    "cline-rules": {
-      "forge": "gitlab",
+    "harness": {
+      "forge": "gitea",
       "visibility": "private",
+      "local_path": "~/internal/harness",
       "role": "consumes SDD methodology + templates"
     },
     "wiki": {
@@ -37,7 +38,7 @@
     "amicron-platform": {
       "forge": "gitlab",
       "visibility": "private",
-      "role": "transitive consumer via cline-rules"
+      "role": "transitive consumer via harness"
     }
   },
   "custom_integrations": [
@@ -50,8 +51,8 @@
     "ci_workflow": ".github/workflows/privacy-check.yml"
   },
   "morning_protocol": {
-    "source": "~/Documents/Cline/Workflows/sod.protocol.md",
-    "eod_source": "~/Documents/Cline/Workflows/eod.protocol.md",
+    "source": "~/internal/harness/workflows/sod.protocol.md",
+    "eod_source": "~/internal/harness/workflows/eod.protocol.md",
     "upstream_sync_check": "scripts/bash/check-upstream-sync.sh",
     "sod_hook": "scripts/bash/sod.sh",
     "eod_hook": "scripts/bash/eod.sh",
@@ -60,7 +61,7 @@
     "docs": "docs/ipadp-l3-automation.md"
   },
   "cline_harmony": {
-    "rules_source": "~/Documents/Cline/Rules/",
+    "rules_source": "~/internal/harness/rules",
     "key_rules": [
       "methodology.core.md",
       "methodology.rlm.md",
@@ -71,6 +72,6 @@
       "agent.framework.md",
       "agent.guardrails.md"
     ],
-    "symlink_script": "~/Documents/Cline/scripts/env-setup-symlinks.sh"
+    "symlink_script": "~/internal/harness/scripts/env-setup-symlinks.sh"
   }
 }


### PR DESCRIPTION
Closes #65.

The satware AG `harness` repo (IPADP project #7, formerly `cline-rules`) was decoupled from Cline: it now lives at `~/internal/harness/` on **Gitea** (`git.satware.ai/satware.ai/harness`), not `~/Documents/Cline/` on GitLab. This updates the stale metadata.

## Changes (all 6 stale fields)
- `downstream.cline-rules` → `downstream.harness` (forge `gitlab`→`gitea`, +`local_path: ~/internal/harness`)
- `amicron-platform.role`: "via cline-rules" → "via harness"
- `morning_protocol.{source,eod_source}` → `~/internal/harness/workflows/`
- `cline_harmony.{rules_source,symlink_script}` → `~/internal/harness/...`

## Two deliberate calls
1. **Omitted the private Gitea `url`** proposed in the issue — this is a public repo and the repo's own privacy validator flags `git.satware.ai`; `wiki`/`amicron-platform` private entries omit URLs by convention. `local_path` gives deterministic discovery without the leak. Happy to add + whitelist on request.
2. **`AGENTS.md` and `scripts/bash/{sod,eod}.sh`** carry the same stale `~/Documents/Cline` paths but are out of scope here (would conflict with #66's AGENTS.md). Recommend a follow-up issue.

## Verification
`json.tool` parses; privacy check clean; all referenced paths resolve on disk.

Assisted-by: opencode (model: glm-5.2, supervised)