### PR TITLE
docs(ipadp): refresh project connections after v0.12.17 sync

### DIFF
--- a/.github/workflows/upstream-sync-check.yml
+++ b/.github/workflows/upstream-sync-check.yml
@@ -64,7 +64,7 @@ jobs:
             "### Action" \
             "1. Create a sync branch: \`git checkout -b sync/upstream-${LATEST} main-speck\`" \
             "2. Merge: \`git merge ${LATEST}\`" \
-            "3. Resolve conflicts, preserve fork agents (agy, bob, iflow, kimi, hermes, cline)." \
+            "3. Resolve conflicts, preserve fork agents (agy, bob, kimi, hermes, cline)." \
             "4. Run \`uv run pytest tests/integrations/ -x -q\`." \
             "5. Open PR to \`main-speck\`; tag \`satware-${LATEST}+1\` after merge." \
             "" \

--- a/.github/workflows/upstream-tag-regression.yml
+++ b/.github/workflows/upstream-tag-regression.yml
@@ -105,7 +105,7 @@ jobs:
         if: steps.pytest.outputs.exit_code != '0'
         run: |
           set -euo pipefail
-          FORK_AGENTS="agy bob iflow kimi hermes cline"
+          FORK_AGENTS="agy bob kimi hermes cline"
           BROKEN=""
           for a in $FORK_AGENTS; do
             if grep -qE "test_integration_${a}\b|integrations/${a}/" pytest.out; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,31 +486,33 @@ internal satware AG `wiki` repository (`specs/rfc-interproject-agentic-developme
 |-------|-------------|-----------------------|
 | L1    | `AGENTS.md` + `specs/metadata.json` with upstream/downstream graph | This file + `specs/metadata.json` |
 | L2    | Privacy validation in CI                                          | `scripts/bash/check-privacy-leaks.sh`, `.privacy-whitelist`, `.github/workflows/privacy-check.yml` |
-| L3    | Automated upstream sync + morning protocol integration            | `scripts/bash/check-upstream-sync.sh`, `.github/workflows/upstream-sync-check.yml`, `scripts/bash/sod.sh`, `scripts/bash/eod.sh`, `scripts/daily-routine.sh`, Cline `sod.protocol.md` / `eod.protocol.md` |
+| L3    | Automated upstream sync + morning protocol integration            | `scripts/bash/check-upstream-sync.sh`, `.github/workflows/upstream-sync-check.yml`, `scripts/bash/sod.sh`, `scripts/bash/eod.sh`, `scripts/daily-routine.sh`, `$SATWARE_HARNESS/workflows/sod.protocol.md` / `eod.protocol.md` |
 
-### Harmony with `~/Documents/Cline`
+### Harmony with the satware harness (`$SATWARE_HARNESS`)
 
 Agents working on this repository MUST follow the global satware AG agent rules
-distributed via the Cline command center. The canonical source of truth is
-`~/Documents/Cline/Rules/`, synchronized into consumer projects via
-`~/Documents/Cline/scripts/env-setup-symlinks.sh`.
+distributed via the harness. The canonical source of truth is
+`$SATWARE_HARNESS/rules/`, synchronized into consumer projects via
+`$SATWARE_HARNESS/scripts/env-setup-symlinks.sh`. The `SATWARE_HARNESS`
+environment variable is exported by `scripts/prepare-env.sh` (run once after
+cloning the harness) and persisted to `~/.config/satware/harness.env`.
 
 Key rules that govern SDD/TDD and day-to-day behavior on spec-kit:
 
 - `methodology.core.md` — core SDD/TDD/RLM methodology
-- `methodology.rlm.md`  — Reasoning, Learning, Memory loop
 - `code.quality.md`     — code quality bar, reviews, refactoring
-- `git.standards.md`    — commit conventions, branch model, PR hygiene
 - `context.management.md` — git-native context and zero-persistence memory
-- `docs.markdown.md`    — markdown + frontmatter rules
 - `agent.framework.md`, `agent.guardrails.md` — operational framework and guardrails
+- `ecosystem.ipadp.md`  — IPADP conformance (this is IPADP project #6)
+- `release.immutability.md` — tag immutability (governs upstream-sync workflow)
+- `code.cross-platform.md` — cross-platform discipline (shell/powershell paths, encodings)
 
 ### Morning / EoD Protocol Integration
 
 At the start of every working session an agent working on this repository SHOULD:
 
-1. Run the repo-local SoD hook: `bash scripts/daily-routine.sh sod` (references harness `~/internal/harness/workflows/sod.protocol.md` when available, then runs `check-privacy-leaks.sh` and `check-upstream-sync.sh`).
-2. At the end of the session, run the repo-local EoD hook: `bash scripts/daily-routine.sh eod` (references harness `~/internal/harness/workflows/eod.protocol.md` when available, then runs `check-privacy-leaks.sh`).
+1. Run the repo-local SoD hook: `bash scripts/daily-routine.sh sod` (references `$SATWARE_HARNESS/workflows/sod.protocol.md` when available, then runs `check-privacy-leaks.sh` and `check-upstream-sync.sh`).
+2. At the end of the session, run the repo-local EoD hook: `bash scripts/daily-routine.sh eod` (references `$SATWARE_HARNESS/workflows/eod.protocol.md` when available, then runs `check-privacy-leaks.sh`).
 
 In CI, `.github/workflows/upstream-sync-check.yml` runs `scripts/bash/check-upstream-sync.sh` on a daily schedule and opens/updates a rolling `upstream-sync: <tag> available` issue when a new upstream `github/spec-kit` release tag is detected.
 
@@ -528,7 +530,7 @@ See `docs/fork-agent-parity.md` for the fork-agent parity audit (IPADP Phase 4.3
 6. **Checklists** — fulfill `templates/checklist-template.md` prior to merge.
 7. **Privacy + upstream sync** — verify via the two scripts above.
 8. **Pre-PR check** — run `bash scripts/daily-routine.sh pre-pr` before pushing to catch lint/test failures locally. Runs ruff, integration tests, privacy check, and upstream sync in a single pass.
-9. **Commit + PR** — follow `git.standards.md` (conventional commits, signed trailers where required).
+9. **Commit + PR** — follow conventional commits (`<type>(<scope>): <msg>`) with signed trailers where required.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -39,6 +39,6 @@ It is IPADP project #6 in the satware AG ecosystem.
 ## IPADP
 
 - RFC: `specs/rfc-interproject-agentic-development.md` in the internal satware AG `wiki` repository
-- Morning protocol (SoD): `~/Documents/Cline/Workflows/sod.protocol.md`
-- EoD protocol: `~/Documents/Cline/Workflows/eod.protocol.md`
-- Global agent rules: `~/Documents/Cline/Rules/`
+- Morning protocol (SoD): `$SATWARE_HARNESS/workflows/sod.protocol.md`
+- EoD protocol: `$SATWARE_HARNESS/workflows/eod.protocol.md`
+- Global agent rules: `$SATWARE_HARNESS/rules/`

--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -27,7 +27,7 @@
     "harness": {
       "forge": "gitea",
       "visibility": "private",
-      "local_path": "~/internal/harness",
+      "local_path": "$SATWARE_HARNESS",
       "role": "consumes SDD methodology + templates"
     },
     "wiki": {
@@ -41,15 +41,15 @@
       "role": "transitive consumer via harness"
     }
   },
-  "custom_integrations": [],
+  "custom_integrations": ["agy", "bob", "cline", "hermes", "iflow", "kimi"],
   "privacy": {
     "validator": "scripts/bash/check-privacy-leaks.sh",
     "whitelist": ".privacy-whitelist",
     "ci_workflow": ".github/workflows/privacy-check.yml"
   },
   "morning_protocol": {
-    "source": "~/internal/harness/workflows/sod.protocol.md",
-    "eod_source": "~/internal/harness/workflows/eod.protocol.md",
+    "source": "$SATWARE_HARNESS/workflows/sod.protocol.md",
+    "eod_source": "$SATWARE_HARNESS/workflows/eod.protocol.md",
     "upstream_sync_check": "scripts/bash/check-upstream-sync.sh",
     "sod_hook": "scripts/bash/sod.sh",
     "eod_hook": "scripts/bash/eod.sh",
@@ -58,17 +58,17 @@
     "docs": "docs/ipadp-l3-automation.md"
   },
   "cline_harmony": {
-    "rules_source": "~/internal/harness/rules",
+    "rules_source": "$SATWARE_HARNESS/rules",
     "key_rules": [
-      "methodology.core.md",
-      "methodology.rlm.md",
-      "code.quality.md",
-      "git.standards.md",
-      "context.management.md",
-      "docs.markdown.md",
       "agent.framework.md",
-      "agent.guardrails.md"
+      "agent.guardrails.md",
+      "code.cross-platform.md",
+      "code.quality.md",
+      "context.management.md",
+      "ecosystem.ipadp.md",
+      "methodology.core.md",
+      "release.immutability.md"
     ],
-    "symlink_script": "~/internal/harness/scripts/env-setup-symlinks.sh"
+    "symlink_script": "$SATWARE_HARNESS/scripts/env-setup-symlinks.sh"
   }
 }

--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -41,7 +41,7 @@
       "role": "transitive consumer via harness"
     }
   },
-  "custom_integrations": ["agy", "bob", "cline", "hermes", "iflow", "kimi"],
+  "custom_integrations": ["agy", "bob", "cline", "hermes", "kimi"],
   "privacy": {
     "validator": "scripts/bash/check-privacy-leaks.sh",
     "whitelist": ".privacy-whitelist",

--- a/specs/upstream-release-sync-strategy/spec.md
+++ b/specs/upstream-release-sync-strategy/spec.md
@@ -15,7 +15,7 @@ This fork (`satwareAG/spec-kit`) adds proprietary agent integrations (cline, her
 |------|-------|
 | Fork version | 0.12.17 (matches upstream release tag `v0.12.17`) |
 | Upstream main | 0.12.18.dev0 (unreleased development) |
-| Custom integrations | 6 fork agents: agy, bob, cline, hermes, iflow, kimi |
+| Custom integrations | 5 fork agents: agy, bob, cline, hermes, kimi |
 | Sync status | Up to date with `v0.12.17` (merged 2026-07-17) |
 
 ### Custom Fork Additions (must survive sync)
@@ -26,9 +26,8 @@ This fork (`satwareAG/spec-kit`) adds proprietary agent integrations (cline, her
 | `src/specify_cli/integrations/bob/` | Bob agent integration |
 | `src/specify_cli/integrations/cline/` | Cline agent integration |
 | `src/specify_cli/integrations/hermes/` | Hermes agent integration |
-| `src/specify_cli/integrations/iflow/` | iFlow agent integration |
 | `src/specify_cli/integrations/kimi/` | Kimi agent integration |
-| `src/specify_cli/integrations/__init__.py` | Modified to register all 6 fork agents |
+| `src/specify_cli/integrations/__init__.py` | Modified to register all 5 fork agents |
 | `pyproject.toml` | Version bumped with fork additions |
 | `CHANGELOG.md` | Fork-specific changelog |
 
@@ -40,7 +39,7 @@ As a maintainer, when upstream publishes a new release tag (e.g., `v0.7.3`), I c
 
 **Why this priority**: Core workflow - without clean sync, fork drifts and becomes unmaintainable.
 
-**Independent Test**: Checkout fork, merge upstream tag `v0.7.3`, run test suite, verify agy, bob, cline, hermes, iflow, kimi integrations still registered and functional.
+**Independent Test**: Checkout fork, merge upstream tag `v0.7.3`, run test suite, verify agy, bob, cline, hermes, kimi integrations still registered and functional.
 
 ### User Story 2 - Skip Unreleased Development Commits (Priority: P1)
 
@@ -56,7 +55,7 @@ As a maintainer, when upstream modifies shared files (e.g., `integrations/__init
 
 **Why this priority**: Conflict resolution is the highest-risk operation; documented procedure prevents accidental loss.
 
-**Independent Test**: Simulate conflict by cherry-picking an upstream commit touching `__init__.py`, resolve using procedure, verify both upstream and all 6 fork integrations registered.
+**Independent Test**: Simulate conflict by cherry-picking an upstream commit touching `__init__.py`, resolve using procedure, verify both upstream and all 5 fork integrations registered.
 
 ### User Story 4 - Validate Fork Integrity After Sync (Priority: P2)
 
@@ -64,7 +63,7 @@ As a maintainer, after syncing to a new release, I can run a validation procedur
 
 **Why this priority**: Quality gate - catches sync issues before push.
 
-**Independent Test**: Run validation script, confirm all checks pass (version matches tag, `specify --help` lists agy, bob, cline, hermes, iflow, kimi, tests green).
+**Independent Test**: Run validation script, confirm all checks pass (version matches tag, `specify --help` lists agy, bob, cline, hermes, kimi, tests green).
 
 ### User Story 5 - Automated Sync Detection (Priority: P3)
 
@@ -96,7 +95,7 @@ After sync, the full test suite (`pytest tests/`) MUST pass with 0 failures.
 
 ### FR-005: Conflict Resolution Procedure
 
-A documented procedure MUST exist for resolving conflicts in shared files (`integrations/__init__.py`) that preserves both upstream additions and the 6 custom fork agent registrations (agy, bob, cline, hermes, iflow, kimi).
+A documented procedure MUST exist for resolving conflicts in shared files (`integrations/__init__.py`) that preserves both upstream additions and the 5 custom fork agent registrations (agy, bob, cline, hermes, kimi).
 
 ### FR-006: IPADP Conformance
 
@@ -114,9 +113,9 @@ The fork MUST maintain `AGENTS.md`, `specs/metadata.json` with upstream/downstre
 |----------|-------------|
 | Sync completes cleanly | Merge of upstream tag produces no unresolved conflicts or at most documented resolution steps |
 | All tests pass | `pytest tests/` returns 0 failures |
-| Integrations functional | `specify init --help` lists agy, bob, cline, hermes, iflow, kimi as available integrations |
+| Integrations functional | `specify init --help` lists agy, bob, cline, hermes, kimi as available integrations |
 | Version correct | `pyproject.toml` version matches merged tag |
-| No custom code lost | `git diff` shows all 6 fork agent directories intact post-merge |
+| No custom code lost | `git diff` shows all 5 fork agent directories intact post-merge |
 
 ## Sync Procedure (Reference Implementation)
 
@@ -134,8 +133,8 @@ git merge-base --is-ancestor $LATEST_TAG HEAD && echo "Already merged" && exit 0
 git merge $LATEST_TAG --no-edit
 
 # 5. Resolve conflicts in shared files if any
-#    - integrations/__init__.py: keep both upstream registrations AND all 6 fork agents
-#      (agy, bob, cline, hermes, iflow, kimi)
+#    - integrations/__init__.py: keep both upstream registrations AND all 5 fork agents
+#      (agy, bob, cline, hermes, kimi)
 
 # 6. Update version in pyproject.toml to match tag
 

--- a/specs/upstream-release-sync-strategy/spec.md
+++ b/specs/upstream-release-sync-strategy/spec.md
@@ -13,22 +13,24 @@ This fork (`satwareAG/spec-kit`) adds proprietary agent integrations (cline, her
 
 | Item | Value |
 |------|-------|
-| Fork version | 0.7.2 (matches upstream release tag `v0.7.2`) |
-| Upstream main | 0.7.3.dev0 (unreleased development) |
-| Custom files | 10 files: cline integration, hermes integration, shared scripts |
-| Upstream drift | 3 commits ahead of `v0.7.2` tag (all dev-phase, no release) |
+| Fork version | 0.12.17 (matches upstream release tag `v0.12.17`) |
+| Upstream main | 0.12.18.dev0 (unreleased development) |
+| Custom integrations | 6 fork agents: agy, bob, cline, hermes, iflow, kimi |
+| Sync status | Up to date with `v0.12.17` (merged 2026-07-17) |
 
 ### Custom Fork Additions (must survive sync)
 
 | File | Purpose |
 |------|---------|
+| `src/specify_cli/integrations/agy/` | AGY agent integration |
+| `src/specify_cli/integrations/bob/` | Bob agent integration |
 | `src/specify_cli/integrations/cline/` | Cline agent integration |
 | `src/specify_cli/integrations/hermes/` | Hermes agent integration |
-| `src/specify_cli/integrations/__init__.py` | Modified to register cline/hermes |
-| `scripts/bash/update-agent-context.sh` | Modified to include cline/hermes |
-| `scripts/powershell/update-agent-context.ps1` | Modified to include cline/hermes |
-| `CHANGELOG.md` | Fork-specific changelog |
+| `src/specify_cli/integrations/iflow/` | iFlow agent integration |
+| `src/specify_cli/integrations/kimi/` | Kimi agent integration |
+| `src/specify_cli/integrations/__init__.py` | Modified to register all 6 fork agents |
 | `pyproject.toml` | Version bumped with fork additions |
+| `CHANGELOG.md` | Fork-specific changelog |
 
 ## User Scenarios & Testing
 
@@ -38,7 +40,7 @@ As a maintainer, when upstream publishes a new release tag (e.g., `v0.7.3`), I c
 
 **Why this priority**: Core workflow - without clean sync, fork drifts and becomes unmaintainable.
 
-**Independent Test**: Checkout fork, merge upstream tag `v0.7.3`, run test suite, verify cline/hermes integrations still registered and functional.
+**Independent Test**: Checkout fork, merge upstream tag `v0.7.3`, run test suite, verify agy, bob, cline, hermes, iflow, kimi integrations still registered and functional.
 
 ### User Story 2 - Skip Unreleased Development Commits (Priority: P1)
 
@@ -54,7 +56,7 @@ As a maintainer, when upstream modifies shared files (e.g., `integrations/__init
 
 **Why this priority**: Conflict resolution is the highest-risk operation; documented procedure prevents accidental loss.
 
-**Independent Test**: Simulate conflict by cherry-picking an upstream commit touching `__init__.py`, resolve using procedure, verify both upstream and custom integrations registered.
+**Independent Test**: Simulate conflict by cherry-picking an upstream commit touching `__init__.py`, resolve using procedure, verify both upstream and all 6 fork integrations registered.
 
 ### User Story 4 - Validate Fork Integrity After Sync (Priority: P2)
 
@@ -62,7 +64,7 @@ As a maintainer, after syncing to a new release, I can run a validation procedur
 
 **Why this priority**: Quality gate - catches sync issues before push.
 
-**Independent Test**: Run validation script, confirm all checks pass (version matches tag, `specify --help` lists cline/hermes, tests green).
+**Independent Test**: Run validation script, confirm all checks pass (version matches tag, `specify --help` lists agy, bob, cline, hermes, iflow, kimi, tests green).
 
 ### User Story 5 - Automated Sync Detection (Priority: P3)
 
@@ -94,7 +96,7 @@ After sync, the full test suite (`pytest tests/`) MUST pass with 0 failures.
 
 ### FR-005: Conflict Resolution Procedure
 
-A documented procedure MUST exist for resolving conflicts in shared files (`integrations/__init__.py`, `update-agent-context.sh/ps1`) that preserves both upstream additions and custom registrations.
+A documented procedure MUST exist for resolving conflicts in shared files (`integrations/__init__.py`) that preserves both upstream additions and the 6 custom fork agent registrations (agy, bob, cline, hermes, iflow, kimi).
 
 ### FR-006: IPADP Conformance
 
@@ -112,9 +114,9 @@ The fork MUST maintain `AGENTS.md`, `specs/metadata.json` with upstream/downstre
 |----------|-------------|
 | Sync completes cleanly | Merge of upstream tag produces no unresolved conflicts or at most documented resolution steps |
 | All tests pass | `pytest tests/` returns 0 failures |
-| Integrations functional | `specify init --help` lists cline and hermes as available integrations |
+| Integrations functional | `specify init --help` lists agy, bob, cline, hermes, iflow, kimi as available integrations |
 | Version correct | `pyproject.toml` version matches merged tag |
-| No custom code lost | `git diff` shows cline/hermes files intact post-merge |
+| No custom code lost | `git diff` shows all 6 fork agent directories intact post-merge |
 
 ## Sync Procedure (Reference Implementation)
 
@@ -132,8 +134,8 @@ git merge-base --is-ancestor $LATEST_TAG HEAD && echo "Already merged" && exit 0
 git merge $LATEST_TAG --no-edit
 
 # 5. Resolve conflicts in shared files if any
-#    - integrations/__init__.py: keep both upstream registrations AND custom cline/hermes
-#    - update-agent-context.sh/ps1: keep both upstream agents AND cline/hermes cases
+#    - integrations/__init__.py: keep both upstream registrations AND all 6 fork agents
+#      (agy, bob, cline, hermes, iflow, kimi)
 
 # 6. Update version in pyproject.toml to match tag
 


### PR DESCRIPTION
Audit of today's v0.12.17 sync (#83) found 5 IPADP connection validity issues - all doc/config-only, no code/test changes.

**Issues fixed:**
1. Stale spec body: Current State v0.7.2 -> v0.12.17, Custom Fork Additions expanded to 5 real agents, dropped dead update-agent-context.{sh,ps1} rows (owned by opt-in agent-context extension)
2. Non-existent key_rules: replaced methodology.rlm.md, git.standards.md, docs.markdown.md (not in $SATWARE_HARNESS/rules/) with release.immutability.md, ecosystem.ipadp.md, code.cross-platform.md
3. Dead ~/Documents/Cline paths -> $SATWARE_HARNESS (portable var exported by harness scripts/prepare-env.sh)
4. Populated empty custom_integrations: agy, bob, cline, hermes, kimi
5. Dropped discontinued iflow from agent lists (per docs/fork-agent-parity.md:34)

**Verification (all green):**
- jq . specs/metadata.json - valid JSON
- grep for stale paths/rule-names/iflow - no matches
- All 8 key_rules files exist in $SATWARE_HARNESS/rules/
- custom_integrations matches from .<agent> import in integrations/__init__.py
- scripts/bash/check-privacy-leaks.sh . - Repository is clean

**Commits (5, atomic):**
- de146b5 docs(spec): refresh upstream-release-sync-strategy to v0.12.17 state
- 096ef15 chore(ipadp): fix metadata key_rules, populate custom_integrations, portable paths
- a3a5a48 docs(ipadp): replace ~/Documents/Cline with $SATWARE_HARNESS, sync key_rules
- 9fe5b65 docs(llms): replace ~/Documents/Cline paths with $SATWARE_HARNESS
- 5092cfb fix(ipadp): drop discontinued iflow from fork agent lists

**Agent disclosure:** Authored and pushed by opencode (model: z-ai/glm-5.2) under direct human supervision by Jane Alesi (@ja). Each commit carries an Assisted-by: opencode (model: z-ai/glm-5.2, supervised) trailer. This PR body and all review-round replies are also agent-generated on behalf of @ja.