### PR TITLE
fix(ipadp): align amicron-platform role, update stale issue_tracker

### DIFF
--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -8,7 +8,7 @@
   "ipadp": {
     "project_number": 6,
     "conformance_level": "L3",
-    "issue_tracker": "https://github.com/satwareAG/spec-kit/issues/6",
+    "issue_tracker": "https://github.com/satwareAG/spec-kit/issues",
     "rfc_location": "<internal>/wiki/specs/rfc-interproject-agentic-development.md"
   },
   "upstream": {
@@ -38,7 +38,7 @@
     "amicron-platform": {
       "forge": "gitlab",
       "visibility": "private",
-      "role": "transitive consumer via harness"
+      "role": "consumes SDD methodology"
     }
   },
   "custom_integrations": ["agy", "bob", "cline", "hermes", "kimi"],


### PR DESCRIPTION
Follow-up to #84. Fixes 2 of the 4 metadata-consistency issues found in the up/downstream relations audit; the other 2 are blocked on harness issue #39 and deferred.

**Issue B - role mismatch (ponytail simplify):**
spec-kit labeled amicron-platform as `"transitive consumer via harness"`, but amicron-platform's own metadata lists spec-kit as a direct upstream (`"methodology-provider"`). The relationship is direct, not transitive. Simplified to `"consumes SDD methodology"` - parallel to the harness entry's `"consumes SDD methodology + templates"`, drops the false transitive claim.

**Issue D - stale issue_tracker:**
`ipadp.issue_tracker` pointed at issue #6 (`[IPADP] Add specs/metadata.json... L1`), which is CLOSED. No single active IPADP tracker issue exists - the upstream-sync rolling issue is auto-managed by CI. Aligned with the harness metadata pattern: point at the repo issues list URL (`https://github.com/satwareAG/spec-kit/issues`), always reachable and meaningful.

**Deferred (blocked on harness #39):**
- Issue A: missing `local_path` for wiki + amicron-platform downstream entries
- Issue C: non-portable `rfc_location` (`<internal>/wiki/...` placeholder)
- Blocked on https://git.satware.ai/satware.ai/harness/issues/39 (proposes `` env var). Follow-up PR once that lands.

**Verification:** jq valid; privacy-check passes (doc-only change).

**Agent disclosure:** Authored and pushed by opencode (model: z-ai/glm-5.2) under direct human supervision by Jane Alesi (@ja). Commit carries Assisted-by trailer. This PR body is agent-generated on behalf of @ja.