### PR TITLE
fix(bundle): post-merge cleanup follow-ups from #87 (upstream v0.13.0)

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -178,6 +178,7 @@ Spec Kit stores project-level extension registration and hook configuration in:
 ```text
 .specify/extensions.yml
 ```
+
 The file contains installed extensions, global settings, and hooks that are surfaced before or after Spec Kit commands.
 
 ```yaml
@@ -225,6 +226,7 @@ Each hook entry supports the following fields:
 | `prompt` | Message shown when asking whether to run an optional hook. |
 | `description` | Human-readable explanation of what the hook does. |
 | `condition` | Optional expression evaluated by `HookExecutor` (using `config.<path>` or `env.<VAR>` with `is set`, `==`, or `!=`). Current command templates do not evaluate conditions and skip hooks with a non-empty condition. |
+
 Hook event names identify when a hook is invoked. They generally use `before_<command>` or `after_<command>`, such as `before_implement`, `after_implement`, `before_tasks`, and `after_tasks`.
 
 `HookExecutor.get_hooks_for_event()` returns hooks ordered by `priority`, with lower values first. However, current command templates read hook lists directly and surface them in their configured YAML order rather than using priority ordering.

--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -826,7 +826,7 @@ def _require_https(label: str, url: str) -> None:
         raise BundlerError(
             f"Refusing to download {label} over non-HTTPS URL: {url}"
         )
-    if not parsed.hostname:
+    if not hostname:
         raise BundlerError(f"Refusing to download {label} from URL with no host: {url}")
 
 


### PR DESCRIPTION
## Summary

Post-merge cleanup items from PR #87 review (issue #88). Two minor, non-blocking items, one commit.

## Changes

### 1. `src/specify_cli/commands/bundle/__init__.py:829` - reuse `hostname` local

After the `ValueError` guard added in upstream v0.13.0, the final host-check re-accessed `parsed.hostname` instead of reusing the `hostname` local captured in the try block. The sibling fix in `src/specify_cli/presets/__init__.py:2093` already uses the local consistently.

```diff
-    if not parsed.hostname:
+    if not hostname:
         raise BundlerError(f"Refusing to download {label} from URL with no host: {url}")
```

Behavior unchanged (`ParseResult` is immutable for a given URL, so a successful first access won't raise on re-access). This is a consistency cleanup to prevent drift in future refactors.

### 2. `docs/reference/extensions.md` - blank lines for CommonMark block separation

Added blank lines after the closing code fence (line 180) and after the hook-fields table (line 227) in the new "Project Extension and Hook Configuration" section introduced by upstream v0.13.0.

## Verification

Acceptance criteria from #88:

- [x] `src/specify_cli/commands/bundle/__init__.py:829` uses `hostname` local
- [x] `docs/reference/extensions.md` has blank lines after the closing fence (line 180) and after the hook-fields table (line 227)
- [x] Existing bundle tests pass: `.venv/bin/python -m pytest tests/unit/test_bundle_download_url.py tests/test_workflows.py -q` -> **651 passed, 1 skipped** (pre-existing skip)
- [x] Broader regression check: `.venv/bin/python -m pytest tests/ --ignore=tests/test_workflows.py -q` -> **3783 passed, 113 skipped** (pre-existing skips)
- [x] `ruff check src/specify_cli/commands/bundle/__init__.py` -> All checks passed
- [x] `pre-pr` privacy check -> clean

Note: the repo's `scripts/daily-routine.sh pre-pr` reports a failure on the `check-upstream-sync.sh` step, but that failure is pre-existing on `main-speck` itself - PR #87 was a squash merge (not a direct tag merge), so `v0.13.0`'s commit SHA is not an ancestor of `main-speck`. Unrelated to this fix; tracked separately.

## Disclosure

Authored and pushed by an AI agent (opencode z-ai/glm-5.2, autonomous) on behalf of @mw. The commit carries the `Assisted-by:` trailer per the repo's agent disclosure policy.

Closes #88