### PR TITLE
chore(scripts): wire provenance check into pre-pr

### DIFF
--- a/scripts/bash/pre-pr.sh
+++ b/scripts/bash/pre-pr.sh
@@ -22,7 +22,7 @@ fail=0
 
 # 1. Ruff lint (matches CI: uvx ruff check src/)
 echo ""
-echo "[1/4] ruff check src/..."
+echo "[1/5] ruff check src/..."
 if uvx --from "ruff>=0.14" ruff check "$REPO_ROOT/src/"; then
     echo "   ruff passed"
 else
@@ -32,7 +32,7 @@ fi
 
 # 2. Integration tests (stop on first failure, quiet)
 echo ""
-echo "[2/4] pytest tests/integrations/ ..."
+echo "[2/5] pytest tests/integrations/ ..."
 if (cd "$REPO_ROOT" && uv run pytest tests/integrations/ -x -q --no-header); then
     echo "   tests passed"
 else
@@ -42,7 +42,7 @@ fi
 
 # 3. Privacy leak check
 echo ""
-echo "[3/4] check-privacy-leaks.sh..."
+echo "[3/5] check-privacy-leaks.sh..."
 if "$REPO_ROOT/scripts/bash/check-privacy-leaks.sh" "$REPO_ROOT"; then
     echo "   privacy check passed"
 else
@@ -52,12 +52,28 @@ fi
 
 # 4. Upstream sync check
 echo ""
-echo "[4/4] check-upstream-sync.sh..."
+echo "[4/5] check-upstream-sync.sh..."
 if "$REPO_ROOT/scripts/bash/check-upstream-sync.sh"; then
     echo "   upstream-sync check completed"
 else
     echo "   upstream-sync check reported issues (non-fatal)"
     # Non-fatal: upstream sync warnings don't block PRs
+fi
+
+# 5. Tool provenance: system `specify` must be the satwareAG fork at a release tag
+#    (rules/tool.provenance.md in the satware harness). Fatal: a stale upstream
+#    or editable install silently shadowing the fork is a real bug class.
+echo ""
+echo "[5/5] check-speckit-cli.sh (tool provenance)..."
+if [ -n "${SATWARE_HARNESS:-}" ] && [ -x "$SATWARE_HARNESS/scripts/check-speckit-cli.sh" ]; then
+    if "$SATWARE_HARNESS/scripts/check-speckit-cli.sh"; then
+        echo "   provenance check passed"
+    else
+        echo "   provenance check FAILED"
+        fail=1
+    fi
+else
+    echo "   skipped (SATWARE_HARNESS not set or check-speckit-cli.sh not found)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Add `[5/5]` step to `scripts/bash/pre-pr.sh` that calls `$SATWARE_HARNESS/scripts/check-speckit-cli.sh` before pushing. Fatal when the system `specify` resolves to anything other than the satwareAG fork at a pushed `satware-v*` release tag.

## Background

A real incident triggered this: an ambient `uv tool install` from upstream `github/spec-kit` was silently shadowing the fork's editable venv (Common Pitfall #6 in this repo's AGENTS.md), running stale `0.8.15.dev0` instead of the satwareAG `v0.13.0` release. The satwareAG fork uses a `satware-vX.Y.Z+N` tag scheme; a local-only `v0.13.0` tag from an upstream leftover was never the satwareAG release.

## Changes

- **`scripts/bash/pre-pr.sh`** (+20/-4): new `[5/5]` step calls `$SATWARE_HARNESS/scripts/check-speckit-cli.sh`. Fatal on exit 2 (foreign / missing / untagged). Skipped gracefully when `SATWARE_HARNESS` is unset or the script is not executable, so contributors without the satware harness can still run pre-pr.
- Updated step labels `[1/4]`...`[4/4]` -> `[1/5]`...`[4/5]`.

## Pairs With

satware/harness PR #64: `feat(security): add tool provenance rule + check script` - adds the `check-speckit-cli.sh` script and `rules/tool.provenance.md` policy that this change invokes.

## Test Plan

- [x] `bash scripts/daily-routine.sh pre-pr` end-to-end: `=== pre-pr: all checks passed ===`
- [x] All 5 steps pass:
  - [1/5] ruff check src/ -> All checks passed
  - [2/5] pytest tests/integrations/ -> 1902 passed, 3 skipped
  - [3/5] check-privacy-leaks.sh -> No violations
  - [4/5] check-upstream-sync.sh -> Non-fatal (expected)
  - [5/5] check-speckit-cli.sh -> `OK: specify 0.13.0 (uv-tool, satware-v0.13.0+1 @ 5ddf6a312a1b)`
- [x] Graceful skip when `SATWARE_HARNESS` unset: prints `skipped (SATWARE_HARNESS not set or check-speckit-cli.sh not found)`

---

🤖 Assisted-by: opencode z-ai/glm-5.2 (autonomous)
