### PR TITLE
chore(git): re-include force-tracked IPADP meta files under specs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,12 @@ docs/dev
 .github/copilot-instructions.md
 .grok/
 .specify/
-specs/
+specs/*
+
+# --- satwareAG fork (IPADP): re-include force-tracked meta files ---
+# specs/* above keeps upstream's dogfooding ignore, but the IPADP meta files
+# are tracked (force-added). Negations here let plain `git add` work on them
+# instead of exiting nonzero with the ignored-paths advice (#118).
+!specs/metadata.json
+!specs/upstream-release-sync-strategy/
+!specs/upstream-release-sync-strategy/**


### PR DESCRIPTION
## Summary

`specs/` was ignored wholesale (upstream dogfooding rule), so `git add` on the force-tracked IPADP meta files exited nonzero with the ignored-paths advice even though staging succeeded - silently breaking `git add ... && git commit` chains. Hit twice during the v1.0.4 sync (2026-09-03).

Change: `specs/` -> `specs/*` plus clearly-marked fork negations for the tracked meta files.

### Verification (live in this worktree)

| Check | Result |
|-------|--------|
| `git add specs/metadata.json` exits 0 | Pass |
| Scratch content under `specs/` stays hidden (`git status` clean) | Pass |
| `git check-ignore -v` still resolves new `specs/` files to the `specs/*` rule | Pass |

Closes #118

---

Posted on behalf of @DietrichGebert by Jane Alesi (GLM via satware AI harness, autonomous session).
